### PR TITLE
Fix FileHandle readLine EOF handling

### DIFF
--- a/MovesenseShowcase/extensions/FileHandle+readLine.swift
+++ b/MovesenseShowcase/extensions/FileHandle+readLine.swift
@@ -29,11 +29,12 @@ extension FileHandle {
                 return lineData
             }
 
-            if (readBuffer.count > 0) == false {
-                return nil
+            if readBuffer.isEmpty {
+                // EOF reached without a delimiter. Return remaining buffer if not empty.
+                return dataBuffer.isEmpty ? nil : dataBuffer
             }
 
-        } while (dataBuffer.count > 0)
+        } while true
 
         return nil
     }


### PR DESCRIPTION
## Summary
- fix `FileHandle.readLine(delimiter:)` so it returns final line when the file
  does not end with the delimiter

## Testing
- `swiftc MovesenseShowcase/extensions/FileHandle+readLine.swift /tmp/main.swift -o /tmp/readline_test && /tmp/readline_test`