### PR TITLE
Fix MDSWrapper API usage

### DIFF
--- a/MAX3000xProgrammer.swift
+++ b/MAX3000xProgrammer.swift
@@ -20,7 +20,7 @@ private enum MAX3000xMdsWriter {
                                   NSNumber(value: Int(value))]
         let fullPath = "/\(deviceSerial)\(registerBasePath)"
 
-        MDSWrapper.sharedInstance().doPut(fullPath, contract: paramsArray) { response in
+        MDSWrapper.shared.doPut(fullPath, contract: paramsArray) { response in
             if response.statusCode == 200 {
                 completion(nil)
             } else {
@@ -35,7 +35,7 @@ private enum MAX3000xMdsWriter {
         let paramsArray: [Any] = [NSNumber(value: Int(address))]
         let fullPath = "/\(deviceSerial)\(registerBasePath)"
 
-        MDSWrapper.sharedInstance().doGet(fullPath, contract: paramsArray) { response in
+        MDSWrapper.shared.doGet(fullPath, contract: paramsArray) { response in
             if response.statusCode == 200 {
                 if let body = response.bodyDictionary, let params = body["Parameters"] as? [NSNumber], params.count == 2 {
                     completion(.success(params[1].uint32Value))
@@ -59,7 +59,7 @@ private enum MAX3000xMdsWriter {
         let paramsArray: [Any] = [NSNumber(value: Int(command))]
         let fullPath = "/\(deviceSerial)\(commandBasePath)"
 
-        MDSWrapper.sharedInstance().doPut(fullPath, contract: paramsArray) { response in
+        MDSWrapper.shared.doPut(fullPath, contract: paramsArray) { response in
             if response.statusCode == 200 {
                 completion(nil)
             } else {

--- a/MAX3000x_Configuration_Guide.md
+++ b/MAX3000x_Configuration_Guide.md
@@ -20,7 +20,7 @@ The `MAX3000xProgrammer.swift` module provides a high-level Swift interface to d
     *   A pre-defined convenience method that executes the specific sequence for an EEG-friendly setup (detailed below).
 
 **Underlying Mechanism:**
-The module uses direct calls to `MDSWrapper.sharedInstance().doPut(...)`, passing parameters as an unnamed JSON array in the `contract` argument. This aligns with the Movesense iOS SDK's method for handling positional parameters for these generic component paths.
+The module uses direct calls to `MDSWrapper.shared.doPut(...)`, passing parameters as an unnamed JSON array in the `contract` argument. This aligns with the Movesense iOS SDK's method for handling positional parameters for these generic component paths.
 
 ## II. Configuring MAX3000x for EEG Measurements
 


### PR DESCRIPTION
## Summary
- update MDSWrapper calls to use `.shared`
- reflect change in configuration guide

## Testing
- `swift test` *(fails: Could not find Package.swift)*